### PR TITLE
Make gameplay layout mobile-friendly

### DIFF
--- a/src/Announcements/index.tsx
+++ b/src/Announcements/index.tsx
@@ -4,8 +4,9 @@ import { GameContext, State } from "../Context";
 import styled from "styled-components";
 
 const AnnouncementsArea = styled.div`
-  height: calc(100% - 150px);
-  overflow: scroll;
+  min-height: 180px;
+  max-height: 320px;
+  overflow: auto;
 `;
 
 const Log = styled.div`

--- a/src/BatterButton/index.tsx
+++ b/src/BatterButton/index.tsx
@@ -13,9 +13,14 @@ type BatterButtonHandle = {
 const Button = styled.button`
   background: aquamarine;
   color: darkblue;
-  padding: 20px;
+  padding: 14px 18px;
   border-radius: 30px;
   cursor: pointer;
+
+  @media (max-width: 700px) {
+    width: 100%;
+    text-align: center;
+  }
 `;
 
 const outfield = {

--- a/src/Diamond/index.tsx
+++ b/src/Diamond/index.tsx
@@ -10,11 +10,15 @@ const OutfieldDiv = styled.div`
   width: 300px;
   background: #AAC32B;
   border-radius: 100% 0 0 0;
-  position: absolute;
-  right: 35px;
-  bottom: 75px;
+  position: relative;
+  margin-left: auto;
   transform: rotate(45deg); /* Equal to rotateZ(45deg) */
-  z-index: -1;
+
+  @media (max-width: 700px) {
+    margin: 0 auto;
+    height: 220px;
+    width: 220px;
+  }
 `;
 
 const DiamondDiv = styled.div`
@@ -24,6 +28,11 @@ const DiamondDiv = styled.div`
   position: absolute;
   bottom: 0;
   right: 0;
+
+  @media (max-width: 700px) {
+    height: 120px;
+    width: 120px;
+  }
 `;
 
 const Mound = styled.div`

--- a/src/Game/GameInner.tsx
+++ b/src/Game/GameInner.tsx
@@ -16,22 +16,35 @@ type Props = {
 
 const GameDiv = styled.main`
   color: white;
-  position: relative;
-  height: 75vh;
-  width: 75vw;
+  min-height: 85vh;
+  width: min(1000px, calc(100vw - 24px));
   border: 1px solid #884e4e;
-  padding: 30px;
+  padding: 20px;
   margin: 0 auto;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  @media (max-width: 700px) {
+    min-height: auto;
+    padding: 14px;
+    width: calc(100vw - 12px);
+  }
 `;
 
 const GameInfo = styled.div`
-  height: 150px;
-  padding: 15px 0;
+  padding: 8px 0;
   
   & > div {
     padding: 5px 0;
   }
+`;
+
+const TeamInputs = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
 `;
 
 const Input = styled.input`
@@ -44,6 +57,12 @@ const Controls = styled.div`
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+
+  label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
 `;
 
 const ShareButton = styled.button`
@@ -52,6 +71,18 @@ const ShareButton = styled.button`
   cursor: pointer;
   background: #f5f5f5;
   color: #000;
+`;
+
+const FieldArea = styled.section`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+
+  @media (max-width: 700px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
 const GameInner: React.FunctionComponent<Props> = ({ homeTeam, awayTeam }) => {
@@ -159,9 +190,13 @@ const GameInner: React.FunctionComponent<Props> = ({ homeTeam, awayTeam }) => {
         <div>Welcome to the game!</div>
         <div>I hope you have a great time!</div>
         <div>
-          The match-up is between <br/>
-          <label><Input value={teams[0]} onChange={handleChangeTeam(0)} /></label> and
-          <label><Input value={teams[1]} onChange={handleChangeTeam(1)} /></label>!
+          The match-up is between
+          <TeamInputs>
+            <label><Input value={teams[0]} onChange={handleChangeTeam(0)} /></label>
+            <span>and</span>
+            <label><Input value={teams[1]} onChange={handleChangeTeam(1)} /></label>
+            <span>!</span>
+          </TeamInputs>
         </div>
 
         <Controls>
@@ -183,8 +218,10 @@ const GameInner: React.FunctionComponent<Props> = ({ homeTeam, awayTeam }) => {
           <ShareButton onClick={handleShareReplay}>Share replay</ShareButton>
         </Controls>
       </GameInfo>
-      <ScoreBoard/>
-      <Diamond/>
+      <FieldArea>
+        <ScoreBoard/>
+        <Diamond/>
+      </FieldArea>
       <Announcements/>
     </GameDiv>
   );

--- a/src/ScoreBoard/index.tsx
+++ b/src/ScoreBoard/index.tsx
@@ -7,12 +7,14 @@ const textColor = "#0F4880";
 
 const ScoreBoardDiv = styled.div`
   background: #fff;
-  height: 190px;
-  width: 120px;
+  min-height: 190px;
+  width: 180px;
   padding: 0 10px;
-  position: absolute;
-  right: 55px;
-  top: 55px;
+
+  @media (max-width: 700px) {
+    width: 100%;
+    box-sizing: border-box;
+  }
 `;
 
 const Score = styled.div`

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,4 +7,6 @@
 
 body {
   background: black;
+  margin: 0;
+  padding: 12px 0;
 }


### PR DESCRIPTION
### Motivation
- The game UI was cluttered on small screens with absolutely positioned elements overlapping and controls unreadable, so the layout needs to be responsive. 
- Improve usability on phones by ensuring scoreboard, field, controls and announcements stack and wrap instead of colliding.

### Description
- Converted the main game container to a responsive flex layout in `src/Game/GameInner.tsx`, added a `FieldArea` wrapper and `TeamInputs` so controls and team name inputs wrap on narrow screens. 
- Reflowed the scoreboard via `src/ScoreBoard/index.tsx` to remove absolute positioning and made it full-width on small viewports. 
- Made the field/diamond responsive in `src/Diamond/index.tsx` by removing fixed anchoring and scaling sizes via media queries. 
- Bounded the announcements area in `src/Announcements/index.tsx`, adjusted the `Batter Up!` button in `src/BatterButton/index.tsx` to be full-width on mobile, and added body spacing in `src/index.scss` so content does not clip at the edges.

### Testing
- Ran a headless browser check (Playwright) to capture a mobile viewport screenshot of the deployed preview and it completed successfully and produced `artifacts/mobile-layout.png`. 
- Attempted a local build with `yarn build`, but it failed due to a missing native `deasync` binary and inability to fetch Node headers in this environment, so the full build could not be validated. 
- Attempted `npm rebuild deasync` to remediate the native module, but the rebuild failed because fetching Node headers was blocked in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996901a97248326a32738c8886cc53d)