### PR TITLE
Add creator attribution link to Home screen

### DIFF
--- a/src/features/gameplay/components/HomeScreen/HomeScreen.test.tsx
+++ b/src/features/gameplay/components/HomeScreen/HomeScreen.test.tsx
@@ -97,6 +97,13 @@ describe("HomeScreen", () => {
     expect(onHelp).toHaveBeenCalled();
   });
 
+  it("shows creator attribution link", () => {
+    render(<HomeScreen onNewGame={noop} onLoadSaves={noop} onManageTeams={noop} />);
+    const creatorLink = screen.getByRole("link", { name: /naftali.dev/i });
+    expect(creatorLink).toBeInTheDocument();
+    expect(creatorLink).toHaveAttribute("href", "https://naftali.dev");
+  });
+
   it("always shows the League play coming soon teaser", () => {
     render(<HomeScreen onNewGame={noop} onLoadSaves={noop} onManageTeams={noop} />);
     expect(screen.getByTestId("league-play-teaser")).toBeInTheDocument();

--- a/src/features/gameplay/components/HomeScreen/index.tsx
+++ b/src/features/gameplay/components/HomeScreen/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { HomeContainer, HomeLogo, HomeSubtitle, LeagueTeaserBox, LeagueTeaserSub, LeagueTeaserTitle, MenuGroup, PrimaryBtn, SecondaryBtn } from "./styles"; // prettier-ignore
+import { Attribution, AttributionLink, HomeContainer, HomeLogo, HomeSubtitle, LeagueTeaserBox, LeagueTeaserSub, LeagueTeaserTitle, MenuGroup, PrimaryBtn, SecondaryBtn } from "./styles"; // prettier-ignore
 
 type Props = {
   onNewGame: () => void;
@@ -61,6 +61,9 @@ const HomeScreen: React.FunctionComponent<Props> = ({
         Season schedules, standings, and playoffs are on the roadmap.
       </LeagueTeaserSub>
     </LeagueTeaserBox>
+    <Attribution>
+      Created by <AttributionLink href="https://naftali.dev">naftali.dev</AttributionLink>
+    </Attribution>
   </HomeContainer>
 );
 

--- a/src/features/gameplay/components/HomeScreen/styles.ts
+++ b/src/features/gameplay/components/HomeScreen/styles.ts
@@ -123,3 +123,25 @@ export const LeagueTeaserSub = styled.p`
   margin: 0;
   line-height: 1.4;
 `;
+
+export const Attribution = styled.p`
+  margin: ${({ theme }) => theme.spacing.sm} 0 0;
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.sub};
+  text-align: center;
+`;
+
+export const AttributionLink = styled.a`
+  color: ${({ theme }) => theme.colors.textLink};
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.textSecondaryLink};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.accentPrimary};
+    outline-offset: 2px;
+    border-radius: ${({ theme }) => theme.radii.xs};
+  }
+`;


### PR DESCRIPTION
### Motivation
- Provide a small, centered attribution footer on the Home screen so the creator is credited in-app.

### Description
- Rendered an attribution block below the league teaser in `HomeContainer` by adding `Attribution` and `AttributionLink` into `src/features/gameplay/components/HomeScreen/index.tsx` and using `href="https://naftali.dev"` for the link.
- Added styled-components `Attribution` and `AttributionLink` to `src/features/gameplay/components/HomeScreen/styles.ts` that use existing theme color, spacing, font-size, and focus/hover tokens so the link appears as muted footer metadata.
- Added a unit test in `src/features/gameplay/components/HomeScreen/HomeScreen.test.tsx` asserting the creator link is present and its `href` equals `https://naftali.dev`.

### Testing
- Ran `yarn lint:fix && yarn format` and `yarn lint`, with repository pre-existing warnings reported but no new lint errors from these changes.
- Built the app with `yarn build`, which completed successfully.
- Ran unit tests with `yarn test`, where the test suite completed (unit tests passed in this environment).
- Ran `yarn test:e2e` in this environment but the end-to-end run failed broadly across suites (failures are not specific to this small change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2df647220832692d368eac572ea00)