### PR TITLE
Allow Copilot setup to repair lockfiles

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,4 +30,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --immutable
+        # Copilot setup prepares the agent workspace, including tasks that may
+        # need to repair package.json/yarn.lock drift. Keep this non-immutable so
+        # the agent can start; immutable installs remain enforced by normal CI.
+        run: yarn install --no-immutable


### PR DESCRIPTION
## Summary

This PR updates the Copilot setup workflow so dependency installation is non-immutable in the agent setup environment.

## Why

Copilot appears to read `.github/workflows/copilot-setup-steps.yml` from the default branch before it starts work on a PR branch. If that setup step runs `yarn install --immutable`, the agent cannot even start when the requested task is to regenerate or repair a stale `yarn.lock`.

This already blocked the Dexie migration PR because `package.json` had new dependencies while `yarn.lock` still needed regeneration.

## What changed

- Changed Copilot setup install from:

```bash
yarn install --immutable
```

- To:

```bash
yarn install --no-immutable
```

- Added a comment explaining that this is only for Copilot workspace setup. Normal CI should continue enforcing immutable installs.

## Validation

This is a workflow-only change. Normal CI/build workflows are unchanged and should continue enforcing lockfile consistency.