### PR TITLE
fix(league): deterministic per-game seeds + fill mixed-mode teams before create

### DIFF
--- a/src/features/league/schedule/generateSchedule.ts
+++ b/src/features/league/schedule/generateSchedule.ts
@@ -200,7 +200,8 @@ export function generateSchedule(input: GenerateScheduleInput): GenerateSchedule
           // Game day: each season round occupies seriesLength consecutive days.
           const gameDay = seasonRoundIdx * seriesLength + g;
           const gameId = generateSeasonGameId();
-          const derivedSeed = deriveScheduledGameSeed(seasonId, gameId);
+          const seedKey = `${seriesId}:g${g}:d${gameDay}`;
+          const derivedSeed = deriveScheduledGameSeed(seasonId, seedKey);
           games.push({
             id: gameId,
             seasonId,

--- a/src/features/leagues/pages/LeagueSetupWizard/index.tsx
+++ b/src/features/leagues/pages/LeagueSetupWizard/index.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 
+import { CustomTeamStore } from "@feat/customTeams/storage/customTeamStore";
+import { generateLeagueTeams } from "@feat/league/autogen/generateLeagueTeams";
 import { createSeason, quickStart } from "@feat/league/storage/leagueStore";
+import { generateTeamId } from "@storage/generateId";
+import { fnv1a } from "@storage/hash";
 import { useActiveSeason } from "@feat/leagues/hooks/useActiveSeason";
 import ModalShell from "@shared/components/ModalShell";
 import StatusBanner from "@shared/components/StatusBanner";
@@ -405,6 +409,55 @@ export default function LeagueSetupWizard(): React.ReactElement {
           },
         });
       } else {
+        let teamIds = state.selectedTeamIds;
+
+        if (state.teamMode === "mixed") {
+          const remainingCount = 8 - state.selectedTeamIds.length;
+          const autogenSubSeed = fnv1a(`${state.masterSeed}:autogen:mixed`);
+          const generated = generateLeagueTeams({
+            count: remainingCount,
+            theme: state.autogenTheme,
+            parity:
+              state.autogenParity <= 25
+                ? "random"
+                : state.autogenParity <= 75
+                  ? "balanced"
+                  : "mixed",
+            masterSeed: state.masterSeed,
+            autogenSubSeed,
+            rosterMinimums: {
+              lineup: 9,
+              bench: 3,
+              startingPitchers: 5,
+              reliefPitchers: 3,
+            },
+            idFactory: { teamId: () => generateTeamId() },
+          });
+
+          for (const gen of generated) {
+            await CustomTeamStore.createCustomTeam(
+              {
+                name: gen.name,
+                abbreviation: gen.abbreviation,
+                nickname: gen.nickname,
+                city: gen.city,
+                slug: gen.slug,
+                roster: {
+                  lineup: gen.roster.lineup,
+                  bench: gen.roster.bench,
+                  pitchers: gen.roster.pitchers,
+                },
+                metadata: gen.metadata,
+                autogen: gen.autogen,
+                statsProfile: gen.statsProfile,
+              },
+              { id: gen.id },
+            );
+          }
+
+          teamIds = [...state.selectedTeamIds, ...generated.map((g) => g.id)];
+        }
+
         season = await createSeason({
           name: "New Season",
           masterSeed: state.masterSeed,
@@ -413,7 +466,7 @@ export default function LeagueSetupWizard(): React.ReactElement {
           leagues: state.leagues.map((l) => ({
             id: l.id,
             name: l.name,
-            teamIds: state.selectedTeamIds,
+            teamIds,
             dhEnabled: l.dhEnabled,
           })),
         });


### PR DESCRIPTION
### Motivation

- The per-game `derivedSeed` was being derived from a random `gameId`, breaking reproducibility for seasons created with the same master seed.  
- The League Setup Wizard mixed-mode path passed only `selectedTeamIds` to `createSeason` which allowed users to finish the wizard but caused downstream schedule generation errors when the remaining slots were expected to be auto-generated.

### Description

- Updated `generateSchedule` to derive each game seed from deterministic schedule coordinates by building `seedKey = `${seriesId}:g${g}:d${gameDay}`` and calling `deriveScheduledGameSeed(seasonId, seedKey)` instead of using the random `gameId` as the seed input.  
- Updated `LeagueSetupWizard` so when `state.teamMode === "mixed"` it computes the `remainingCount`, derives a deterministic `autogenSubSeed` via `fnv1a(`${state.masterSeed}:autogen:mixed`)`, calls `generateLeagueTeams(...)`, persists each generated team with `CustomTeamStore.createCustomTeam(..., { id: gen.id })`, and assembles a complete 8-team `teamIds` list passed to `createSeason`.  
- Added the required imports (`CustomTeamStore`, `generateLeagueTeams`, `generateTeamId`, `fnv1a`) and preserved `gameId` generation for unique DB IDs while removing its influence over the game PRNG seed.

### Testing

- Ran `yarn vitest src/features/league/schedule/generateSchedule.test.ts src/features/leagues/wizard/validateWizardState.test.ts` and both test files passed.  
- Test run summary: `2 files passed`, `24 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a8d8a9548326b54f8650b718da23)